### PR TITLE
Fix enum retrieval in PhpUnitUtil

### DIFF
--- a/tests/Unit/Utils/PhpUnitUtilTest.php
+++ b/tests/Unit/Utils/PhpUnitUtilTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Utils;
+
+use App\General\Domain\Enum\Language;
+use App\Tests\Utils\PhpUnitUtil;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @package App\Tests\Unit\Utils
+ */
+class PhpUnitUtilTest extends TestCase
+{
+    public function testGetValidValueReturnsConsistentEnumCase(): void
+    {
+        $method = new ReflectionMethod(PhpUnitUtil::class, 'getValidValue');
+        $method->setAccessible(true);
+
+        $firstValue = $method->invoke(null, null, Language::class);
+        $secondValue = $method->invoke(null, null, Language::class);
+
+        self::assertSame($firstValue, $secondValue);
+    }
+}

--- a/tests/Utils/PhpUnitUtil.php
+++ b/tests/Utils/PhpUnitUtil.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Throwable;
 
 use function array_key_exists;
+use function array_key_first;
 use function explode;
 use function sprintf;
 use function str_contains;
@@ -279,7 +280,12 @@ class PhpUnitUtil
         }
 
         $output = match ($type) {
-            self::TYPE_ENUM => current($class::cases()), // TODO: fix this
+            self::TYPE_ENUM => (static function (string $enumClass): mixed {
+                $cases = $enumClass::cases();
+                $firstKey = array_key_first($cases);
+
+                return $firstKey === null ? null : $cases[$firstKey];
+            })($class),
             self::TYPE_CUSTOM_CLASS => new $class(...$params),
             self::TYPE_INT, self::TYPE_INTEGER => 666,
             self::TYPE_STRING => 'Some text here',


### PR DESCRIPTION
## Summary
- replace the enum case selection in PhpUnitUtil with a deterministic lookup that avoids mutating the cases array
- add a unit test that ensures repeated invocations on the same enum return the same value

## Testing
- not run (dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d159964cc8832697e2189ce76b2b15