### PR TITLE
Add follow status aggregation and mutual follow test

### DIFF
--- a/src/User/Domain/Repository/Interfaces/FollowRepositoryInterface.php
+++ b/src/User/Domain/Repository/Interfaces/FollowRepositoryInterface.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace App\User\Domain\Repository\Interfaces;
 
+use App\User\Domain\Entity\User;
+
 /**
  * @package App\Follow
  */
+
 interface FollowRepositoryInterface
 {
-
+    /**
+     * @return array<string, int>
+     */
+    public function getFollowStatuses(User $user): array;
 }

--- a/src/User/Infrastructure/Repository/FollowRepository.php
+++ b/src/User/Infrastructure/Repository/FollowRepository.php
@@ -6,6 +6,7 @@ namespace App\User\Infrastructure\Repository;
 
 use App\General\Infrastructure\Repository\BaseRepository;
 use App\User\Domain\Entity\Follow as Entity;
+use App\User\Domain\Entity\User;
 use App\User\Domain\Repository\Interfaces\FollowRepositoryInterface;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -34,5 +35,53 @@ class FollowRepository extends BaseRepository implements FollowRepositoryInterfa
     public function __construct(
         protected ManagerRegistry $managerRegistry,
     ) {
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getFollowStatuses(User $user): array
+    {
+        $queryBuilder = $this->createQueryBuilder('follow')
+            ->addSelect('follower', 'followed')
+            ->join('follow.follower', 'follower')
+            ->join('follow.followed', 'followed')
+            ->where('follow.follower = :user OR follow.followed = :user')
+            ->setParameter('user', $user);
+
+        $relations = $queryBuilder
+            ->getQuery()
+            ->getResult();
+
+        $statuses = [];
+        $userId = $user->getId();
+
+        foreach ($relations as $relation) {
+            if (!$relation instanceof Entity) {
+                continue;
+            }
+
+            $followerId = $relation->getFollower()->getId();
+            $followedId = $relation->getFollowed()->getId();
+
+            if ($followerId === $userId) {
+                $statuses[$followedId] = ($statuses[$followedId] ?? 0) | 0b10;
+            }
+
+            if ($followedId === $userId) {
+                $statuses[$followerId] = ($statuses[$followerId] ?? 0) | 0b01;
+            }
+        }
+
+        foreach ($statuses as $otherUserId => $mask) {
+            $statuses[$otherUserId] = match ($mask) {
+                0b11 => 1,
+                0b10 => 2,
+                0b01 => 3,
+                default => 0,
+            };
+        }
+
+        return $statuses;
     }
 }

--- a/src/User/Transport/Controller/Api/v1/Profile/ProfileController.php
+++ b/src/User/Transport/Controller/Api/v1/Profile/ProfileController.php
@@ -181,35 +181,16 @@ readonly class ProfileController
             $document['stories'][$key]['expiresAt']  = $story->getExpiresAt();
         }
         $allUsers = $this->userRepository->findAll();
+        $followStatuses = $this->followRepository->getFollowStatuses($user);
 
         foreach ($allUsers as $key => $otherUser) {
             if ($otherUser === $user) {
                 continue;
             }
 
-            $iFollowHim = $this->followRepository->findOneBy([
-                'follower' => $user,
-                'followed' => $otherUser,
-            ]);
-
-            $heFollowsMe = $this->followRepository->findOneBy([
-                'follower' => $otherUser,
-                'followed' => $user,
-            ]);
-
-            if ($iFollowHim && $heFollowsMe) {
-                $status = 1;
-            } elseif ($iFollowHim && !$heFollowsMe) {
-                $status = 2;
-            } elseif (!$iFollowHim && $heFollowsMe) {
-                $status = 3;
-            } else {
-                $status = 0;
-            }
-
             $document['friends'][$key] = [
                 'user' => $otherUser->getId(),
-                'status' => $status,
+                'status' => $followStatuses[$otherUser->getId()] ?? 0,
             ];
         }
 

--- a/src/User/Transport/Controller/Api/v1/Profile/StoryController.php
+++ b/src/User/Transport/Controller/Api/v1/Profile/StoryController.php
@@ -127,6 +127,7 @@ readonly class StoryController
     private function clearFriendsStory(User $loggedInUser): array
     {
         $allUsers = $this->userRepository->findAll();
+        $followStatuses = $this->followRepository->getFollowStatuses($loggedInUser);
 
         $friends = [];
         foreach ($allUsers as $key => $otherUser) {
@@ -134,17 +135,7 @@ readonly class StoryController
                 continue;
             }
 
-            $iFollowHim = $this->followRepository->findOneBy([
-                'follower' => $loggedInUser,
-                'followed' => $otherUser,
-            ]);
-
-            $heFollowsMe = $this->followRepository->findOneBy([
-                'follower' => $otherUser,
-                'followed' => $loggedInUser,
-            ]);
-
-            if ($iFollowHim && $heFollowsMe) {
+            if (($followStatuses[$otherUser->getId()] ?? 0) === 1) {
                 $friends[$key] = $otherUser->getId();
             }
         }

--- a/tests/Unit/User/Infrastructure/Repository/FollowRepositoryTest.php
+++ b/tests/Unit/User/Infrastructure/Repository/FollowRepositoryTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Infrastructure\Repository;
+
+use App\User\Domain\Entity\Follow;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\FollowRepository;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Throwable;
+
+/**
+ * @package App\Tests\Unit\User\Infrastructure\Repository
+ */
+final class FollowRepositoryTest extends KernelTestCase
+{
+    private FollowRepository $followRepository;
+    private UserRepository $userRepository;
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * @throws Throwable
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $container = static::getContainer();
+        $this->followRepository = $container->get(FollowRepository::class);
+        $this->userRepository = $container->get(UserRepository::class);
+        $this->entityManager = $container->get('doctrine')->getManager();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testGetFollowStatusesMatchesLegacyCalculationWithSingleQuery(): void
+    {
+        $currentUser = $this->getUserByUsername('john');
+        $mutualFriend = $this->getUserByUsername('john-logged');
+        $followedOnly = $this->getUserByUsername('john-api');
+        $followerOnly = $this->getUserByUsername('john-admin');
+        $noRelation = $this->getUserByUsername('john-root');
+
+        $this->createFollow($currentUser, $mutualFriend);
+        $this->createFollow($mutualFriend, $currentUser);
+        $this->createFollow($currentUser, $followedOnly);
+        $this->createFollow($followerOnly, $currentUser);
+
+        $allUsers = $this->userRepository->findAll();
+
+        $expectedStatuses = [];
+
+        foreach ($allUsers as $user) {
+            if ($user === $currentUser) {
+                continue;
+            }
+
+            $iFollowHim = $this->followRepository->findOneBy([
+                'follower' => $currentUser,
+                'followed' => $user,
+            ]) !== null;
+
+            $heFollowsMe = $this->followRepository->findOneBy([
+                'follower' => $user,
+                'followed' => $currentUser,
+            ]) !== null;
+
+            if ($iFollowHim && $heFollowsMe) {
+                $status = 1;
+            } elseif ($iFollowHim) {
+                $status = 2;
+            } elseif ($heFollowsMe) {
+                $status = 3;
+            } else {
+                $status = 0;
+            }
+
+            $expectedStatuses[$user->getId()] = $status;
+        }
+
+        $debugStack = new DebugStack();
+        $connection = $this->entityManager->getConnection();
+        $configuration = $connection->getConfiguration();
+        $previousLogger = $configuration->getSQLLogger();
+        $configuration->setSQLLogger($debugStack);
+
+        $actualStatuses = $this->followRepository->getFollowStatuses($currentUser);
+
+        $configuration->setSQLLogger($previousLogger);
+
+        $normalizedActual = [];
+        foreach ($allUsers as $user) {
+            if ($user === $currentUser) {
+                continue;
+            }
+
+            $normalizedActual[$user->getId()] = $actualStatuses[$user->getId()] ?? 0;
+        }
+
+        self::assertSame($expectedStatuses, $normalizedActual);
+        self::assertCount(1, $debugStack->queries);
+        self::assertArrayHasKey($noRelation->getId(), $normalizedActual);
+        self::assertSame(1, $normalizedActual[$mutualFriend->getId()]);
+        self::assertSame(2, $normalizedActual[$followedOnly->getId()]);
+        self::assertSame(3, $normalizedActual[$followerOnly->getId()]);
+        self::assertSame(0, $normalizedActual[$noRelation->getId()]);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createFollow(User $follower, User $followed): void
+    {
+        $follow = new Follow($follower, $followed);
+        $this->entityManager->persist($follow);
+        $this->entityManager->flush();
+    }
+
+    private function getUserByUsername(string $username): User
+    {
+        $user = $this->userRepository->findOneBy([
+            'username' => $username,
+        ]);
+
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- add a repository method that aggregates follow statuses for a user in a single query
- update profile and story controllers to rely on the aggregated statuses
- add a unit test to ensure the aggregated statuses match the legacy computation and require only one query

## Testing
- unable to run tests; `composer install` requires GitHub authentication (403 while downloading packages)


------
https://chatgpt.com/codex/tasks/task_e_68d15983a5c883269eb40e93297afd58