### PR TITLE
Validate tenant parameter

### DIFF
--- a/src/General/Transport/EventSubscriber/TenantSubscriber.php
+++ b/src/General/Transport/EventSubscriber/TenantSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Transport\EventSubscriber;
+
+use App\General\Transport\Rest\RequestHandler;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @package App\General
+ */
+final class TenantSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly ManagerRegistry $managerRegistry)
+    {
+    }
+
+    /**
+     * @return array<string, array<int, string>|string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        RequestHandler::setAllowedTenants(array_keys($this->managerRegistry->getManagerNames()));
+    }
+}

--- a/tests/Unit/General/Transport/Rest/RequestHandlerTest.php
+++ b/tests/Unit/General/Transport/Rest/RequestHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Transport\Rest;
+
+use App\General\Transport\Rest\RequestHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * @package App\Tests\Unit
+ */
+class RequestHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        RequestHandler::setAllowedTenants([]);
+    }
+
+    public function testGetTenantReturnsValidTenant(): void
+    {
+        RequestHandler::setAllowedTenants(['default', 'secondary']);
+        $request = new Request(['tenant' => 'secondary']);
+
+        self::assertSame('secondary', RequestHandler::getTenant($request));
+    }
+
+    public function testGetTenantThrowsOnUnknownTenant(): void
+    {
+        RequestHandler::setAllowedTenants(['default']);
+        $request = new Request(['tenant' => 'unknown']);
+
+        try {
+            RequestHandler::getTenant($request);
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+            self::assertSame("Unknown tenant 'unknown'.", $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track allowed tenants within RequestHandler and reject unknown tenant values with a 400 response
- initialize the tenant allow-list from Doctrine manager names through a kernel request subscriber
- cover tenant validation with unit tests for valid and invalid requests

## Testing
- composer install --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium *(fails: GitHub download blocked with 403 requiring credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d1598e598083269e6894a30e8c5c3e