### PR TITLE
Handle story upload failures and add tests

### DIFF
--- a/src/User/Domain/Exception/StoryUploadException.php
+++ b/src/User/Domain/Exception/StoryUploadException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+final class StoryUploadException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        private readonly int $statusCode,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public static function missingFile(): self
+    {
+        return new self('No file provided for story upload.', 400);
+    }
+
+    public static function moveFailed(?Throwable $previous = null): self
+    {
+        return new self('Failed to store story file.', 500, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/tests/Integration/User/Transport/Controller/Api/v1/Profile/StoryControllerTest.php
+++ b/tests/Integration/User/Transport/Controller/Api/v1/Profile/StoryControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\User\Transport\Controller\Api\v1\Profile;
+
+use App\Tests\TestCase\WebTestCase;
+use App\User\Application\Service\UserService;
+use App\User\Domain\Exception\StoryUploadException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+use function file_put_contents;
+use function json_decode;
+use function sys_get_temp_dir;
+use function tempnam;
+
+final class StoryControllerTest extends WebTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function testUploadStoryWithoutFileReturnsBadRequest(): void
+    {
+        $client = $this->getTestClient('john', 'password', server: ['CONTENT_TYPE' => 'multipart/form-data']);
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/story', [], [], ['CONTENT_TYPE' => 'multipart/form-data']);
+
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $data = json_decode((string)$response->getContent(), true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('error', $data);
+        self::assertSame('No file provided for story upload.', $data['error']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testUploadStoryMoveFailureReturnsServerError(): void
+    {
+        $container = static::getContainer();
+        $originalService = $container->get(UserService::class);
+
+        /** @var UserService&MockObject $mockService */
+        $mockService = $this->createMock(UserService::class);
+        $mockService->method('uploadStory')->willThrowException(StoryUploadException::moveFailed());
+
+        $container->set(UserService::class, $mockService);
+
+        try {
+            $client = $this->getTestClient('john', 'password', server: ['CONTENT_TYPE' => 'multipart/form-data']);
+
+            $tempFile = tempnam(sys_get_temp_dir(), 'story');
+            file_put_contents($tempFile, 'content');
+            $uploadedFile = new UploadedFile($tempFile, 'story.txt', 'text/plain', null, true);
+
+            $client->request(
+                'POST',
+                self::API_URL_PREFIX . '/v1/story',
+                [],
+                ['file' => $uploadedFile],
+                ['CONTENT_TYPE' => 'multipart/form-data']
+            );
+
+            $response = $client->getResponse();
+
+            self::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+
+            $data = json_decode((string)$response->getContent(), true);
+            self::assertIsArray($data);
+            self::assertArrayHasKey('error', $data);
+            self::assertSame('Failed to store story file.', $data['error']);
+        } finally {
+            $container->set(UserService::class, $originalService);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `StoryUploadException` and raise it when the upload story service receives no file or fails to move it
- make the v1 story controller return 4xx/5xx JSON responses instead of serialising `null`
- cover the error paths with an integration test suite for the controller

## Testing
- `vendor/bin/phpunit --testsuite=Integration --filter=StoryControllerTest` *(fails: phpunit binary unavailable because dependencies could not be installed without GitHub access)*
- `composer install --no-interaction` *(fails: missing extensions in the environment)*
- `composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails: cannot reach GitHub to download dependencies)*
- `composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium --no-plugins` *(fails: cannot reach GitHub to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d15988dadc8326bb0a57caf6706b77