### PR TITLE
Add media DTOs, resources, mappers, and API tests

### DIFF
--- a/src/Media/Application/DTO/File/File.php
+++ b/src/Media/Application/DTO/File/File.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\File;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\DTO\RestDto;
+use App\General\Application\Validator\Constraints as AppAssert;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Media\Domain\Entity\File as Entity;
+use App\Media\Domain\Entity\Folder as FolderEntity;
+use App\Media\Domain\Enum\FileType;
+use App\User\Domain\Entity\User;
+use Override;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Media
+ *
+ * @method self|RestDtoInterface get(string $id)
+ * @method self|RestDtoInterface patch(RestDtoInterface $dto)
+ * @method Entity|EntityInterface update(EntityInterface $entity)
+ */
+class File extends RestDto
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected FileType $type = FileType::OTHER;
+
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(max: 255)]
+    protected string $url = '';
+
+    protected bool $isPrivate = false;
+
+    protected bool $isFavorite = false;
+
+    #[Assert\Length(max: 10)]
+    protected ?string $extension = null;
+
+    #[Assert\NotNull]
+    #[Assert\PositiveOrZero]
+    protected int $size = 0;
+
+    #[AppAssert\EntityReferenceExists(entityClass: FolderEntity::class)]
+    protected ?FolderEntity $folder = null;
+
+    protected ?User $user = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->setVisited('name');
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getType(): FileType
+    {
+        return $this->type;
+    }
+
+    public function setType(FileType $type): self
+    {
+        $this->setVisited('type');
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): self
+    {
+        $this->setVisited('url');
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->isPrivate;
+    }
+
+    public function setIsPrivate(bool $isPrivate): self
+    {
+        $this->setVisited('isPrivate');
+        $this->isPrivate = $isPrivate;
+
+        return $this;
+    }
+
+    public function isFavorite(): bool
+    {
+        return $this->isFavorite;
+    }
+
+    public function setIsFavorite(bool $isFavorite): self
+    {
+        $this->setVisited('isFavorite');
+        $this->isFavorite = $isFavorite;
+
+        return $this;
+    }
+
+    public function getExtension(): ?string
+    {
+        return $this->extension;
+    }
+
+    public function setExtension(?string $extension): self
+    {
+        $this->setVisited('extension');
+        $this->extension = $extension;
+
+        return $this;
+    }
+
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    public function setSize(int $size): self
+    {
+        $this->setVisited('size');
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function getFolder(): ?FolderEntity
+    {
+        return $this->folder;
+    }
+
+    public function setFolder(?FolderEntity $folder): self
+    {
+        $this->setVisited('folder');
+        $this->folder = $folder;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->setVisited('user');
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->name = $entity->getName();
+            $this->type = $entity->getType();
+            $this->url = $entity->getUrl();
+            $this->isPrivate = $entity->isPrivate();
+            $this->isFavorite = $entity->isFavorite();
+            $this->extension = $entity->getExtension();
+            $this->size = $entity->getSize();
+            $this->folder = $entity->getFolder();
+            $this->user = $entity->getUser();
+        }
+
+        return $this;
+    }
+}

--- a/src/Media/Application/DTO/File/FileCreate.php
+++ b/src/Media/Application/DTO/File/FileCreate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\File;
+
+/**
+ * @package App\Media
+ */
+class FileCreate extends File
+{
+}

--- a/src/Media/Application/DTO/File/FilePatch.php
+++ b/src/Media/Application/DTO/File/FilePatch.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\File;
+
+/**
+ * @package App\Media
+ */
+class FilePatch extends File
+{
+}

--- a/src/Media/Application/DTO/File/FileUpdate.php
+++ b/src/Media/Application/DTO/File/FileUpdate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\File;
+
+/**
+ * @package App\Media
+ */
+class FileUpdate extends File
+{
+}

--- a/src/Media/Application/DTO/Folder/Folder.php
+++ b/src/Media/Application/DTO/Folder/Folder.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\Folder;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\DTO\RestDto;
+use App\General\Application\Validator\Constraints as AppAssert;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Media\Domain\Entity\Folder as Entity;
+use App\User\Domain\Entity\User;
+use Override;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Media
+ *
+ * @method self|RestDtoInterface get(string $id)
+ * @method self|RestDtoInterface patch(RestDtoInterface $dto)
+ * @method Entity|EntityInterface update(EntityInterface $entity)
+ */
+class Folder extends RestDto
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(max: 255)]
+    protected string $name = '';
+
+    #[AppAssert\EntityReferenceExists(entityClass: Entity::class)]
+    protected ?Entity $parent = null;
+
+    protected bool $isPrivate = false;
+
+    protected bool $isFavorite = false;
+
+    protected ?User $user = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->setVisited('name');
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getParent(): ?Entity
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?Entity $parent): self
+    {
+        $this->setVisited('parent');
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->isPrivate;
+    }
+
+    public function setIsPrivate(bool $isPrivate): self
+    {
+        $this->setVisited('isPrivate');
+        $this->isPrivate = $isPrivate;
+
+        return $this;
+    }
+
+    public function isFavorite(): bool
+    {
+        return $this->isFavorite;
+    }
+
+    public function setIsFavorite(bool $isFavorite): self
+    {
+        $this->setVisited('isFavorite');
+        $this->isFavorite = $isFavorite;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->setVisited('user');
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->name = $entity->getName();
+            $this->parent = $entity->getParent();
+            $this->isPrivate = $entity->isPrivate();
+            $this->isFavorite = $entity->isFavorite();
+            $this->user = $entity->getUser();
+        }
+
+        return $this;
+    }
+}

--- a/src/Media/Application/DTO/Folder/FolderCreate.php
+++ b/src/Media/Application/DTO/Folder/FolderCreate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\Folder;
+
+/**
+ * @package App\Media
+ */
+class FolderCreate extends Folder
+{
+}

--- a/src/Media/Application/DTO/Folder/FolderPatch.php
+++ b/src/Media/Application/DTO/Folder/FolderPatch.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\Folder;
+
+/**
+ * @package App\Media
+ */
+class FolderPatch extends Folder
+{
+}

--- a/src/Media/Application/DTO/Folder/FolderUpdate.php
+++ b/src/Media/Application/DTO/Folder/FolderUpdate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\DTO\Folder;
+
+/**
+ * @package App\Media
+ */
+class FolderUpdate extends Folder
+{
+}

--- a/src/Media/Application/Resource/FileResource.php
+++ b/src/Media/Application/Resource/FileResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\Resource;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Rest\RestResource;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Media\Domain\Entity\File as Entity;
+use App\Media\Infrastructure\Repository\FileRepository as Repository;
+
+/**
+ * @package App\Media
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity getReference(string $id, ?string $entityManagerName = null)
+ * @method Repository getRepository()
+ * @method Entity[] find(?array $criteria = null, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity|null findOne(string $id, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity create(RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity update(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity patch(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity delete(string $id, ?bool $flush = null, ?string $entityManagerName = null)
+ * @method Entity save(EntityInterface $entity, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class FileResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Media/Application/Resource/FolderResource.php
+++ b/src/Media/Application/Resource/FolderResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Application\Resource;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Rest\RestResource;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Media\Domain\Entity\Folder as Entity;
+use App\Media\Infrastructure\Repository\FolderRepository as Repository;
+
+/**
+ * @package App\Media
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity getReference(string $id, ?string $entityManagerName = null)
+ * @method Repository getRepository()
+ * @method Entity[] find(?array $criteria = null, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity|null findOne(string $id, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity create(RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity update(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity patch(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity delete(string $id, ?bool $flush = null, ?string $entityManagerName = null)
+ * @method Entity save(EntityInterface $entity, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class FolderResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Media/Transport/AutoMapper/File/AutoMapperConfiguration.php
+++ b/src/Media/Transport/AutoMapper/File/AutoMapperConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Transport\AutoMapper\File;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Media\Application\DTO\File\FileCreate;
+use App\Media\Application\DTO\File\FilePatch;
+use App\Media\Application\DTO\File\FileUpdate;
+
+/**
+ * @package App\Media
+ */
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    /**
+     * @var array<int, class-string>
+     */
+    protected static array $requestMapperClasses = [
+        FileCreate::class,
+        FileUpdate::class,
+        FilePatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Media/Transport/AutoMapper/File/RequestMapper.php
+++ b/src/Media/Transport/AutoMapper/File/RequestMapper.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Transport\AutoMapper\File;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+use App\Media\Application\Resource\FolderResource;
+use App\Media\Domain\Entity\Folder as FolderEntity;
+use App\Media\Domain\Enum\FileType;
+use InvalidArgumentException;
+use Throwable;
+
+use function filter_var;
+use function is_bool;
+use function is_int;
+use function is_string;
+use function is_numeric;
+
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOLEAN;
+
+/**
+ * @package App\Media
+ */
+class RequestMapper extends RestRequestMapper
+{
+    /**
+     * @var array<int, non-empty-string>
+     */
+    protected static array $properties = [
+        'name',
+        'type',
+        'url',
+        'isPrivate',
+        'isFavorite',
+        'extension',
+        'size',
+        'folder',
+    ];
+
+    public function __construct(private readonly FolderResource $folderResource)
+    {
+    }
+
+    protected function transformType(string $type): FileType
+    {
+        return FileType::tryFrom($type) ?? throw new InvalidArgumentException('Invalid file type');
+    }
+
+    protected function transformIsPrivate(bool|int|string|null $isPrivate): bool
+    {
+        return $this->normalizeBoolean($isPrivate);
+    }
+
+    protected function transformIsFavorite(bool|int|string|null $isFavorite): bool
+    {
+        return $this->normalizeBoolean($isFavorite);
+    }
+
+    protected function transformSize(int|string $size): int
+    {
+        if (is_int($size)) {
+            return $size;
+        }
+
+        if (!is_numeric($size)) {
+            throw new InvalidArgumentException('Invalid size value');
+        }
+
+        return (int)$size;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function transformFolder(?string $folder): ?FolderEntity
+    {
+        if ($folder === null || $folder === '') {
+            return null;
+        }
+
+        return $this->folderResource->getReference($folder);
+    }
+
+    private function normalizeBoolean(bool|int|string|null $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        if ($value === null || $value === '') {
+            return false;
+        }
+
+        if (!is_string($value)) {
+            throw new InvalidArgumentException('Invalid boolean value');
+        }
+
+        $normalized = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if ($normalized === null) {
+            throw new InvalidArgumentException('Invalid boolean value');
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Media/Transport/AutoMapper/Folder/AutoMapperConfiguration.php
+++ b/src/Media/Transport/AutoMapper/Folder/AutoMapperConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Transport\AutoMapper\Folder;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Media\Application\DTO\Folder\FolderCreate;
+use App\Media\Application\DTO\Folder\FolderPatch;
+use App\Media\Application\DTO\Folder\FolderUpdate;
+
+/**
+ * @package App\Media
+ */
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    /**
+     * @var array<int, class-string>
+     */
+    protected static array $requestMapperClasses = [
+        FolderCreate::class,
+        FolderUpdate::class,
+        FolderPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Media/Transport/AutoMapper/Folder/RequestMapper.php
+++ b/src/Media/Transport/AutoMapper/Folder/RequestMapper.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Media\Transport\AutoMapper\Folder;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+use App\Media\Application\Resource\FolderResource;
+use App\Media\Domain\Entity\Folder as FolderEntity;
+use InvalidArgumentException;
+use Throwable;
+
+use function filter_var;
+use function is_bool;
+use function is_int;
+use function is_string;
+
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOLEAN;
+
+/**
+ * @package App\Media
+ */
+class RequestMapper extends RestRequestMapper
+{
+    /**
+     * @var array<int, non-empty-string>
+     */
+    protected static array $properties = [
+        'name',
+        'parent',
+        'isPrivate',
+        'isFavorite',
+    ];
+
+    public function __construct(private readonly FolderResource $folderResource)
+    {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function transformParent(?string $parent): ?FolderEntity
+    {
+        if ($parent === null || $parent === '') {
+            return null;
+        }
+
+        return $this->folderResource->getReference($parent);
+    }
+
+    protected function transformIsPrivate(bool|int|string|null $isPrivate): bool
+    {
+        return $this->normalizeBoolean($isPrivate);
+    }
+
+    protected function transformIsFavorite(bool|int|string|null $isFavorite): bool
+    {
+        return $this->normalizeBoolean($isFavorite);
+    }
+
+    private function normalizeBoolean(bool|int|string|null $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        if ($value === null || $value === '') {
+            return false;
+        }
+
+        if (!is_string($value)) {
+            throw new InvalidArgumentException('Invalid boolean value');
+        }
+
+        $normalized = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if ($normalized === null) {
+            throw new InvalidArgumentException('Invalid boolean value');
+        }
+
+        return $normalized;
+    }
+}

--- a/tests/Application/Media/Transport/Controller/Api/v1/File/FileControllerTest.php
+++ b/tests/Application/Media/Transport/Controller/Api/v1/File/FileControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Media\Transport\Controller\Api\v1\File;
+
+use App\General\Domain\Utils\JSON;
+use App\Media\Domain\Entity\File as FileEntity;
+use App\Media\Domain\Enum\FileType;
+use App\Media\Infrastructure\Repository\FileRepository;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class FileControllerTest extends WebTestCase
+{
+    private static string $baseUrl = self::API_URL_PREFIX . '/v1/file';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/file/{id}` request requires authentication.')]
+    public function testThatGetFileRequiresAuthentication(): void
+    {
+        $file = $this->createFile();
+
+        $client = $this->getTestClient();
+        $client->request('GET', self::$baseUrl . '/' . $file->getId());
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/file/{id}` returns file data for the authenticated user.')]
+    public function testThatGetFileReturnsDataForAuthenticatedUser(): void
+    {
+        $file = $this->createFile();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::$baseUrl . '/' . $file->getId());
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('name', $responseData);
+        self::assertArrayHasKey('url', $responseData);
+        self::assertSame($file->getName(), $responseData['name']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `DELETE /api/v1/file/{id}` removes the file for the authenticated user.')]
+    public function testThatDeleteFileRemovesEntity(): void
+    {
+        $file = $this->createFile();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('DELETE', self::$baseUrl . '/' . $file->getId());
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $deleted = $this->getFileRepository()->find($file->getId());
+        self::assertNull($deleted);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createFile(): FileEntity
+    {
+        self::bootKernel();
+
+        $file = new FileEntity();
+        $file->setName('Test file');
+        $file->setUrl('https://example.com/file.pdf');
+        $file->setSize(512);
+        $file->setType(FileType::PDF);
+        $file->setExtension('pdf');
+        $file->setUser($this->getRootUser());
+        $file->setIsPrivate(false);
+        $file->setIsFavorite(false);
+
+        $this->getFileRepository()->save($file);
+
+        return $file;
+    }
+
+    private function getFileRepository(): FileRepository
+    {
+        self::bootKernel();
+        /** @var FileRepository $repository */
+        $repository = self::getContainer()->get(FileRepository::class);
+
+        return $repository;
+    }
+
+    private function getRootUser(): User
+    {
+        self::bootKernel();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['username' => 'john-root']);
+        self::assertNotNull($user);
+
+        return $user;
+    }
+}

--- a/tests/Application/Media/Transport/Controller/Api/v1/Folder/FolderControllerTest.php
+++ b/tests/Application/Media/Transport/Controller/Api/v1/Folder/FolderControllerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Media\Transport\Controller\Api\v1\Folder;
+
+use App\General\Domain\Utils\JSON;
+use App\Media\Domain\Entity\Folder as FolderEntity;
+use App\Media\Infrastructure\Repository\FolderRepository;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class FolderControllerTest extends WebTestCase
+{
+    private static string $baseUrl = self::API_URL_PREFIX . '/v1/folder';
+
+    #[TestDox('Test that `GET /api/v1/folder` request requires authentication.')]
+    public function testThatGetFolderCollectionRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', self::$baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/folder` returns data for an authenticated user.')]
+    public function testThatGetFolderCollectionReturnsDataForAuthenticatedUser(): void
+    {
+        $this->createFolder('Existing folder');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::$baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertNotEmpty($responseData);
+        self::assertIsArray($responseData[0]);
+        self::assertArrayHasKey('id', $responseData[0]);
+        self::assertArrayHasKey('name', $responseData[0]);
+    }
+
+    #[TestDox('Test that `POST /api/v1/folder` request requires authentication.')]
+    public function testThatCreateFolderRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('POST', self::$baseUrl, content: JSON::encode(['name' => 'New folder']));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    #[TestDox('Test that `POST /api/v1/folder` creates a folder for the authenticated user.')]
+    public function testThatCreateFolderReturnsFolderDataForAuthenticatedUser(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $requestData = [
+            'name' => 'API created folder',
+            'isPrivate' => false,
+            'isFavorite' => true,
+        ];
+
+        $client->request('POST', self::$baseUrl, content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertSame($requestData['name'], $responseData['name']);
+        self::assertSame($requestData['isFavorite'], $responseData['isFavorite']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `PUT /api/v1/folder/{id}` updates folder data for the authenticated user.')]
+    public function testThatUpdateFolderUpdatesEntity(): void
+    {
+        $folder = $this->createFolder('Folder to update');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            method: 'PUT',
+            uri: self::$baseUrl . '/' . $folder->getId(),
+            content: JSON::encode(['name' => 'Updated folder name'])
+        );
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('Updated folder name', $responseData['name']);
+
+        $updatedFolder = $this->getFolderRepository()->find($folder->getId());
+        self::assertNotNull($updatedFolder);
+        self::assertSame('Updated folder name', $updatedFolder->getName());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createFolder(string $name): FolderEntity
+    {
+        self::bootKernel();
+
+        $folder = new FolderEntity();
+        $folder->setName($name);
+        $folder->setUser($this->getRootUser());
+
+        $repository = $this->getFolderRepository();
+        $repository->save($folder);
+
+        return $folder;
+    }
+
+    private function getFolderRepository(): FolderRepository
+    {
+        self::bootKernel();
+        /** @var FolderRepository $repository */
+        $repository = self::getContainer()->get(FolderRepository::class);
+
+        return $repository;
+    }
+
+    private function getRootUser(): User
+    {
+        self::bootKernel();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['username' => 'john-root']);
+        self::assertNotNull($user);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce File and Folder DTOs for the media module, including create/update/patch variants that mirror entity fields
- wire new FileResource and FolderResource classes to reuse the existing repositories within the REST infrastructure
- implement media-specific AutoMapper request mappers/configurations and add API tests covering folder and file endpoints

## Testing
- `composer install --no-interaction` *(fails: missing ext-amqp and ext-sodium extensions)*
- `composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails: GitHub 403 while cloning composer-bin-plugin)*
- `composer install --no-interaction --no-plugins --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails: GitHub 403 while cloning symfony/flex)*

------
https://chatgpt.com/codex/tasks/task_e_68d15dcc49588326bcf6a9ec6bf8a21b