### PR TITLE
Normalize search terms in request handler

### DIFF
--- a/src/General/Transport/Rest/RequestHandler.php
+++ b/src/General/Transport/Rest/RequestHandler.php
@@ -276,7 +276,10 @@ final class RequestHandler
     private static function normalizeSearchTerms(array $searchTerms): array
     {
         // Normalize user input, note that this support array and string formats on value
-        array_walk($searchTerms, static fn (array $terms): array => array_unique(array_values(array_filter($terms))));
+        foreach ($searchTerms as &$terms) {
+            $terms = array_unique(array_values(array_filter($terms)));
+        }
+        unset($terms);
 
         return $searchTerms;
     }

--- a/tests/Unit/General/Transport/Rest/RequestHandlerTest.php
+++ b/tests/Unit/General/Transport/Rest/RequestHandlerTest.php
@@ -43,4 +43,21 @@ class RequestHandlerTest extends TestCase
             self::assertSame("Unknown tenant 'unknown'.", $exception->getMessage());
         }
     }
+
+    public function testGetSearchTermsNormalizesDuplicateAndEmptyValues(): void
+    {
+        $request = new Request([
+            'search' => json_encode([
+                'and' => ['foo', '', 'bar', 'foo'],
+                'or' => ['baz', 'baz', '', 'qux'],
+            ]),
+        ]);
+
+        $expected = [
+            'and' => ['foo', 'bar'],
+            'or' => ['baz', 'qux'],
+        ];
+
+        self::assertSame($expected, RequestHandler::getSearchTerms($request));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure RequestHandler::normalizeSearchTerms mutates the search term arrays by reference so filtered unique values are retained
- add a unit test covering duplicate and empty search term values in JSON payloads to confirm normalized output

## Testing
- ⚠️ `composer install --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails: requires GitHub token to download packages via API, preventing phpunit setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d16e7d6ad48326b0a118f825e8669e