### PR TITLE
Align password reset mail context and add test

### DIFF
--- a/src/User/Application/Service/UserRegistrationMailer.php
+++ b/src/User/Application/Service/UserRegistrationMailer.php
@@ -67,7 +67,7 @@ class UserRegistrationMailer implements UserRegistrationMailerInterface
             ->html(
                 $this->twig->render('Emails/password_verification.html.twig', [
                     'user' => $user,
-                    'verification_url' => $verificationUrl,
+                    'reset_password_url' => $verificationUrl,
                 ])
             );
 

--- a/src/User/Application/Service/UserVerificationMailer.php
+++ b/src/User/Application/Service/UserVerificationMailer.php
@@ -67,7 +67,7 @@ class UserVerificationMailer implements UserVerificationMailerInterface
             ->html(
                 $this->twig->render('Emails/password_verification.html.twig', [
                     'user' => $user,
-                    'verification_url' => $verificationUrl,
+                    'reset_password_url' => $verificationUrl,
                 ])
             );
 

--- a/src/User/Transport/Controller/Api/v1/Auth/ResetPasswordController.php
+++ b/src/User/Transport/Controller/Api/v1/Auth/ResetPasswordController.php
@@ -64,7 +64,7 @@ final readonly class ResetPasswordController
             ->hashPassword(new SecurityUser($user, []), $plainPassword);
         $user->setPassword($callback, $password);
         $user->setVerificationToken($token);
-        $frontendUrl = 'https://bro-world-space.com/verify-email?token=' . $user->getVerificationToken();
+        $frontendUrl = 'https://bro-world-space.com/reset-password?token=' . $user->getVerificationToken();
         $this->registrationMailer->sendVerificationPassword($user, $frontendUrl);
         $this->userResource->save($user);
 

--- a/tests/Unit/User/Application/Service/UserRegistrationMailerTest.php
+++ b/tests/Unit/User/Application/Service/UserRegistrationMailerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Application\Service;
+
+use App\User\Application\Service\UserRegistrationMailer;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Twig\Environment;
+
+final class UserRegistrationMailerTest extends TestCase
+{
+    public function testSendVerificationPasswordUsesResetPasswordUrl(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+        $twig = $this->createMock(Environment::class);
+
+        $resetUrl = 'https://example.com/reset-password?token=token';
+
+        $user = new User();
+        $user->setEmail('user@example.com');
+
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(static function (Email $email) use ($resetUrl, $user): bool {
+                self::assertSame('admin@bro-world.de', $email->getFrom()[0]->getAddress());
+                self::assertSame($user->getEmail(), $email->getTo()[0]->getAddress());
+                self::assertStringContainsString($resetUrl, $email->getHtmlBody());
+
+                return true;
+            }));
+
+        $twig->expects(self::once())
+            ->method('render')
+            ->with(
+                'Emails/password_verification.html.twig',
+                self::callback(static function (array $context) use ($resetUrl, $user): bool {
+                    self::assertArrayHasKey('user', $context);
+                    self::assertSame($user, $context['user']);
+                    self::assertArrayHasKey('reset_password_url', $context);
+                    self::assertSame($resetUrl, $context['reset_password_url']);
+
+                    return true;
+                })
+            )
+            ->willReturn(sprintf('<a href="%s">Reset</a>', $resetUrl));
+
+        $mailerService = new UserRegistrationMailer($mailer, $twig);
+
+        $mailerService->sendVerificationPassword($user, $resetUrl);
+    }
+}


### PR DESCRIPTION
## Summary
- align password reset email context keys with the Twig template
- point the reset password notification to the reset-password frontend route
- cover the password reset mailer with a unit test that asserts the reset link is rendered

## Testing
- composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium *(fails: network restrictions when cloning symfony/flex)*

------
https://chatgpt.com/codex/tasks/task_e_68d17682e4c4832686e5d71fe5c7462d